### PR TITLE
Use base36 for suffix

### DIFF
--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -29,8 +29,19 @@ def get_environ_name_for_cname(app_name, cname):
     raise ValueError('Could not find environment for applied app_name and cname')
 
 
+def base36encode(num):
+    result = ""
+    base = 36
+    nchar = '0123456789abcdefghijklmnopqrstuvwxyz'
+    n = int(num)
+    while n > 0:
+        result = nchar[n % base] + result
+        n //= base
+    return result
+
+
 def make_next_env_names(base_env_name, base_cname):
-    suffix = '-' + str(int(time.time()))
+    suffix = '-' + str(base36encode(int(time.time())))
     return base_env_name + suffix, base_cname + suffix
 
 


### PR DESCRIPTION
Fix too long suffix.

Now, suffix like `-1453448682`.
but Beanstalk only alllow EnvironmentName length in range:4-23,
If suffix use 11chars, application name must be under 12 chars.

if use base36, suffix length became 7chars before 2038
and app can use 16 chars.
sample: `-o1cg6i`

ex: decode is easy.

```
def base36decode(b36text):
    return int(b36text, 36)
```
