### PR TITLE
Support multiple configurations for `ebi create`

### DIFF
--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -38,9 +38,9 @@ def main(parsed):
     try:
         sys.exit(subprocess.call(payload))
     finally:
-        if os.path.exists(temp_cfg_path):
-            os.remove(temp_cfg_path)
-            logger.info('removed local temporary cfg: %s', temp_cfg_path)
+        if len(parsed.cfg) > 1 and os.path.exists(temp_cfg_location):
+            os.remove(temp_cfg_location)
+            logger.info('removed local temporary cfg: %s', temp_cfg_location)
 
 
 def apply_args(parser):

--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -30,9 +30,9 @@ def main(parsed):
         if len(parsed.cfg) == 1:
             payload.append('--cfg=' + parsed.cfg[0])
         else:
-            temp_cfg_path = merge_configs(parsed.cfg)
-            logger.info('Set multiple cfgs, merged as: %s', temp_cfg_path)
-            payload.append('--cfg=' + temp_cfg_path)
+            temp_cfg_location, temp_cfg_name = merge_configs(parsed.cfg)
+            logger.info('Set multiple cfgs, merged as: %s', temp_cfg_location)
+            payload.append('--cfg=' + temp_cfg_name)
     if parsed.region:
         payload.append('--region=' + parsed.region)
     try:

--- a/ebi/utils.py
+++ b/ebi/utils.py
@@ -1,0 +1,49 @@
+import yaml
+import os
+from functools import reduce
+
+CONFIG_DIR = '.elasticbeanstalk'
+CONFIG_EXT = '.cfg.yml'
+FILENAME_DELIMITER =  '__'
+
+def merge_configs(config_names):
+    composed = _compose(
+        yaml.load,
+        _read_file,
+        _make_fullpath,
+    )
+
+    configs = [composed(config_name) for config_name in config_names]
+    merged = reduce(lambda a, b: _merge_dict(b, a), configs)
+
+    temp_filename = FILENAME_DELIMITER.join(config_names) + CONFIG_EXT
+    temp_filepath = os.path.join(os.getcwd(), CONFIG_DIR, temp_filename)
+    _make_temp_ymlfile(merged, temp_filepath)
+    return temp_filepath
+
+def _make_temp_ymlfile(data, filepath):
+    dirname = os.path.dirname(filepath)
+    os.makedirs(dirname, exist_ok=True)
+    with open(filepath, 'w') as f:
+        yaml.dump(data, f, default_flow_style=False)
+
+def _read_file(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+def _compose(*functions):
+    initiator = lambda x: x
+    compose2 = lambda f, g: (lambda x: f(g(x)))
+    return reduce(compose2 , functions, initiator)
+
+def _make_fullpath(cfg):
+    return os.path.join(CONFIG_DIR, cfg + CONFIG_EXT)
+
+def _merge_dict(source, destination):
+    for key, value in source.items():
+        if isinstance(value, dict):
+            node = destination.setdefault(key, {})
+            _merge_dict(value, node)
+        else:
+            destination[key] = value
+    return destination

--- a/ebi/utils.py
+++ b/ebi/utils.py
@@ -2,6 +2,8 @@ import os
 
 from functools import reduce
 
+from ebcli.operations import saved_configs
+
 import yaml
 
 
@@ -20,7 +22,7 @@ def merge_configs(cfg_names):
     process_cfg = _compose(
         yaml.load,
         _read_file,
-        _make_fullpath,
+        saved_configs.resolve_config_location
     )
 
     configs = [process_cfg(cfg_name) for cfg_name in cfg_names]
@@ -50,8 +52,6 @@ def _compose(*functions):
     compose2 = lambda f, g: (lambda x: f(g(x)))
     return reduce(compose2, functions, initiator)
 
-def _make_fullpath(cfg):
-    return os.path.join(CONFIG_DIR, cfg + CONFIG_EXT)
 
 def _merge_dict(source, destination):
     for key, value in source.items():

--- a/ebi/utils.py
+++ b/ebi/utils.py
@@ -1,40 +1,54 @@
-import yaml
 import os
+
 from functools import reduce
 
-CONFIG_DIR = '.elasticbeanstalk'
-CONFIG_EXT = '.cfg.yml'
-FILENAME_DELIMITER =  '__'
+import yaml
 
-def merge_configs(config_names):
-    composed = _compose(
+
+CONFIG_DIR = '.elasticbeanstalk'
+SAVED_CONFIG_DIR = 'saved_configs'
+CONFIG_EXT = '.cfg.yml'
+CONFIG_NAME_DELIMITER = '__'
+
+
+def merge_configs(cfg_names):
+    """Merge config files and save as a single ymlfile.
+
+    :param cfg_names: List of config_name string, following ebcli's naming rule
+    :return: String of merged file path, with dir and extenstion
+    """
+    process_cfg = _compose(
         yaml.load,
         _read_file,
         _make_fullpath,
     )
 
-    configs = [composed(config_name) for config_name in config_names]
+    configs = [process_cfg(cfg_name) for cfg_name in cfg_names]
     merged = reduce(lambda a, b: _merge_dict(b, a), configs)
 
-    temp_filename = FILENAME_DELIMITER.join(config_names) + CONFIG_EXT
-    temp_filepath = os.path.join(os.getcwd(), CONFIG_DIR, temp_filename)
+    temp_filename = CONFIG_NAME_DELIMITER.join(cfg_names) + CONFIG_EXT
+    temp_filepath = os.path.join(os.getcwd(),
+                                 CONFIG_DIR, SAVED_CONFIG_DIR, temp_filename)
     _make_temp_ymlfile(merged, temp_filepath)
     return temp_filepath
+
 
 def _make_temp_ymlfile(data, filepath):
     dirname = os.path.dirname(filepath)
     os.makedirs(dirname, exist_ok=True)
-    with open(filepath, 'w') as f:
-        yaml.dump(data, f, default_flow_style=False)
+    with open(filepath, 'w') as wf:
+        yaml.dump(data, wf, default_flow_style=False)
+
 
 def _read_file(path):
-    with open(path, 'r') as f:
-        return f.read()
+    with open(path, 'r') as rf:
+        return rf.read()
+
 
 def _compose(*functions):
     initiator = lambda x: x
     compose2 = lambda f, g: (lambda x: f(g(x)))
-    return reduce(compose2 , functions, initiator)
+    return reduce(compose2, functions, initiator)
 
 def _make_fullpath(cfg):
     return os.path.join(CONFIG_DIR, cfg + CONFIG_EXT)

--- a/ebi/utils.py
+++ b/ebi/utils.py
@@ -16,8 +16,10 @@ CONFIG_NAME_DELIMITER = '__'
 def merge_configs(cfg_names):
     """Merge config files and save as a single ymlfile.
 
-    :param cfg_names: List of config_name string, following ebcli's naming rule
-    :return: String of merged file path, with dir and extenstion
+    :param cfg_names: List of config_name string, without dir or extension
+    :return: Tuple of (String of merged file location with dir and extenstion,
+                       String of merged file name without dir or extenstion)
+    ['ourproj', 'myenv'] -> ('/home/user/..../ourproj__myenv.cfg.yml', 'ourproj__myenv')
     """
     process_cfg = _compose(
         yaml.load,
@@ -28,11 +30,12 @@ def merge_configs(cfg_names):
     configs = [process_cfg(cfg_name) for cfg_name in cfg_names]
     merged = reduce(lambda a, b: _merge_dict(b, a), configs)
 
-    temp_filename = CONFIG_NAME_DELIMITER.join(cfg_names) + CONFIG_EXT
-    temp_filepath = os.path.join(os.getcwd(),
+    temp_cfg_name = CONFIG_NAME_DELIMITER.join(cfg_names)
+    temp_filename =  temp_cfg_name + CONFIG_EXT
+    temp_cfg_location = os.path.join(os.getcwd(),
                                  CONFIG_DIR, SAVED_CONFIG_DIR, temp_filename)
     _make_temp_ymlfile(merged, temp_filepath)
-    return temp_filepath
+    return temp_cfg_location, temp_cfg_name
 
 
 def _make_temp_ymlfile(data, filepath):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     install_requires=[
         'awsebcli>=3.7.3,<4',
         'boto3>=1.2.6,<2',
-        'PyYAML>=3.12,4',
+        'PyYAML>=3.12,<4',
     ],
     description='Simple CLI tool for ElasticBeanstalk with Docker',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open('./README.rst').read()
 
 setup(
     name='ebi',
-    version='0.6.4',
+    version='0.6.5',
     install_requires=[
         'awsebcli>=3.7.3,<4',
         'boto3>=1.2.6,<2',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     install_requires=[
         'awsebcli>=3.7.3,<4',
         'boto3>=1.2.6,<2',
+        'PyYAML>=3.12,4',
     ],
     description='Simple CLI tool for ElasticBeanstalk with Docker',
     long_description=long_description,


### PR DESCRIPTION
Inspired by [jekyll's configuration](https://jekyllrb.com/docs/configuration/).

>  `--config FILE1[,FILE2,...]`
> Configuration
> Specify config files instead of using _config.yml automatically. 
> Settings in later files override settings in earlier files. 

This feature helps us to tune configurations depending on situations like [dev/prod] environments.

### Usage example

```
# already saved
# .elasticbeanstalk/our_project.cfg.yml
# .elasticbeanstalk/my_environment.cfg.yml

ebi create appname envname cname --cfg our_project my_environment
```

