### PR TITLE
Temporary Fixing urllib3 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     install_requires=[
         'awsebcli>=3.7.3,<4',
         'boto3>=1.2.6,<2',
+        'urllib3<1.23',
     ],
     description='Simple CLI tool for ElasticBeanstalk with Docker',
     long_description=long_description,


### PR DESCRIPTION
now, ebi can not be installed due to an error.

Reason:
pip dependency resolver could not find urllib3 version.

botocore 11.0 has not vendored requests and urllib3.
https://github.com/boto/botocore/blob/develop/CHANGELOG.rst
(botocore 11.0 released at 2018/8/25)

```
awsebcli==3.14.4
  - blessed [required: >=1.9.5, installed: 1.15.0]
    - six [required: >=1.9.0, installed: 1.11.0]
    - wcwidth [required: >=0.1.4, installed: 0.1.7]
  - botocore [required: >=1.0.1, installed: 1.11.2]
    - docutils [required: >=0.10, installed: 0.14]
    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.3]
    - python-dateutil [required: >=2.1,<3.0.0, installed: 2.7.3]
      - six [required: >=1.5, installed: 1.11.0]
    - urllib3 [required: >=1.20,<1.24, installed: 1.22]
  - cement [required: ==2.8.2, installed: 2.8.2]
  - colorama [required: >=0.3.9,<0.4.0, installed: 0.3.9]
  - docker-compose [required: >=1.21.2,<1.22.0, installed: 1.21.2]
    - cached-property [required: >=1.2.0,<2, installed: 1.4.3]
    - docker [required: >=3.3.0,<4.0, installed: 3.5.0]
      - docker-pycreds [required: >=0.3.0, installed: 0.3.0]
        - six [required: >=1.4.0, installed: 1.11.0]
      - requests [required: >=2.14.2,!=2.18.0, installed: 2.18.4]
        - certifi [required: >=2017.4.17, installed: 2018.8.24]
        - chardet [required: >=3.0.2,<3.1.0, installed: 3.0.4]
        - idna [required: >=2.5,<2.7, installed: 2.6]
        - urllib3 [required: >=1.21.1,<1.23, installed: 1.22]
      - six [required: >=1.4.0, installed: 1.11.0]
      - websocket-client [required: >=0.32.0, installed: 0.51.0]
        - six [required: Any, installed: 1.11.0]
    - dockerpty [required: >=0.4.1,<0.5, installed: 0.4.1]
      - six [required: >=1.3.0, installed: 1.11.0]
    - docopt [required: >=0.6.1,<0.7, installed: 0.6.2]
    - jsonschema [required: >=2.5.1,<3, installed: 2.6.0]
    - PyYAML [required: >=3.10,<4, installed: 3.13]
    - requests [required: >=2.6.1,<2.19,!=2.18.0,!=2.12.2,!=2.11.0, installed: 2.18.4]
      - certifi [required: >=2017.4.17, installed: 2018.8.24]
      - chardet [required: >=3.0.2,<3.1.0, installed: 3.0.4]
      - idna [required: >=2.5,<2.7, installed: 2.6]
      - urllib3 [required: >=1.21.1,<1.23, installed: 1.22]
    - six [required: >=1.3.0,<2, installed: 1.11.0]
    - texttable [required: >=0.9.0,<0.10, installed: 0.9.1]
    - websocket-client [required: >=0.32.0,<1.0, installed: 0.51.0]
      - six [required: Any, installed: 1.11.0]
  - pathspec [required: ==0.5.5, installed: 0.5.5]
  - python-dateutil [required: >=2.1,<3.0.0, installed: 2.7.3]
    - six [required: >=1.5, installed: 1.11.0]
  - PyYAML [required: >=3.10,<=3.13, installed: 3.13]
  - semantic-version [required: ==2.5.0, installed: 2.5.0]
  - setuptools [required: >=20.0, installed: 40.2.0]
  - six [required: ==1.11.0, installed: 1.11.0]
  - tabulate [required: ==0.7.5, installed: 0.7.5]
  - termcolor [required: ==1.1.0, installed: 1.1.0]
```