### PR TITLE
Add `description` option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ This will
 options:
 
 * ``--version``: version label for app. default is timestamp.
+* ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
@@ -59,6 +60,7 @@ This will
 options:
 
 * ``--version``: version label for app. default is timestamp.
+* ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
@@ -94,6 +96,7 @@ options:
 
 * ``--noswap``: Skip swapping to just deploy secondary environment.
 * ``--version``: version label for app. default is timestamp.
+* ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
@@ -127,6 +130,7 @@ This will
 
 * ``--noswap``: Skip swapping to just deploy secondary environment.
 * ``--version``: version label for app. default is timestamp.
+* ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.

--- a/ebi/appversion.py
+++ b/ebi/appversion.py
@@ -56,7 +56,7 @@ def upload_app_version(app_name, bundled_zip):
     return bucket, key
 
 
-def make_application_version(app_name, version, dockerrun, ebext):
+def make_application_version(app_name, version, dockerrun, ebext, description):
     bundled_zip = make_version_file(version, dockerrun=dockerrun, ebext=ebext)
     try:
         bucket, key = upload_app_version(app_name, bundled_zip)
@@ -66,6 +66,7 @@ def make_application_version(app_name, version, dockerrun, ebext):
         eb.create_application_version(
             ApplicationName=app_name,
             VersionLabel=version,
+            Description=description,
             SourceBundle={
                 'S3Bucket': bucket,
                 'S3Key': key,

--- a/ebi/commands/bgdeploy.py
+++ b/ebi/commands/bgdeploy.py
@@ -61,7 +61,12 @@ def main(parsed):
     else:
         version = str(int(time.time()))
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext)
+    if parsed.description:
+        description = parsed.description
+    else:
+        description = ''
+
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext, description)
     logger.info('Ok, now deploying the version %s for %s', version, secondary_env_name)
     payload = ['eb', 'deploy', secondary_env_name,
                '--version=' + version]
@@ -127,6 +132,7 @@ def apply_args(parser):
                                          'environment',
                         action='store_true', default=False)
     parser.add_argument('--version', help='Version label you want to specify')
+    parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')

--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -76,7 +76,12 @@ def main(parsed):
     else:
         version = str(int(time.time()))
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext)
+    if parsed.description:
+        description = parsed.description
+    else:
+        description = ''
+
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext, description)
     logger.info('Ok, now deploying the version %s for %s', version, next_env_name)
     payload = ['eb', 'deploy', next_env_name,
                '--version=' + version]
@@ -117,6 +122,7 @@ def apply_args(parser):
                                          'environment',
                         action='store_true', default=False)
     parser.add_argument('--version', help='Version label you want to specify')
+    parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')

--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -14,7 +14,12 @@ def main(parsed):
     else:
         version = str(int(time.time()))
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext)
+    if parsed.description:
+        description = parsed.description
+    else:
+        description = ''
+
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext, description)
 
     logger.info('Ok, now creating version %s for environment %s', version, parsed.env_name)
     payload = ['eb', 'create', parsed.env_name,
@@ -35,6 +40,7 @@ def apply_args(parser):
     parser.add_argument('env_name', help='Environ name to deploy')
     parser.add_argument('cname', help='cname for created server')
     parser.add_argument('--version', help='Version label you want to specify')
+    parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')

--- a/ebi/commands/deploy.py
+++ b/ebi/commands/deploy.py
@@ -14,7 +14,12 @@ def main(parsed):
     else:
         version = str(int(time.time()))
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext)
+    if parsed.description:
+        description = parsed.description
+    else:
+        description = ''
+
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext, description)
     logger.info('Ok, now deploying the version %s for %s', version, parsed.env_name)
     payload = ['eb', 'deploy', parsed.env_name,
                '--version=' + version]
@@ -31,6 +36,7 @@ def apply_args(parser):
     parser.add_argument('app_name', help='Application name to deploy')
     parser.add_argument('env_name', help='Environ name to deploy')
     parser.add_argument('--version', help='Version label you want to specify')
+    parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')


### PR DESCRIPTION
### Problem
When I want to rollback to a specific app version, It is hard to detect which the target is on AWS web console.
Basically, it displays only timestamps.


### What I want to do
I would like to add  an option `description`, which can be displayed on ElasticBeanstalk's `Application Version` section.
It will be helpful for finding rollback target that some notes are set as `description` such as commit message or id.

Thanks