### PR TITLE
Add docker-compose mode and version prefix param (ver 0.9.0)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ options:
 * ``--prefix``: version prefix for app. It is added to timestamp.
 * ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
-* ``--docker_compose``: File path used as ``docker-compose.yml``.
+* ``--docker-compose``: File path used as ``docker-compose.yml``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.
@@ -66,7 +66,7 @@ options:
 * ``--prefix``: version prefix for app. It is added to timestamp.
 * ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
-* ``--docker_compose``: File path used as ``docker-compose.yml``.
+* ``--docker-compose``: File path used as ``docker-compose.yml``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.
@@ -104,7 +104,7 @@ options:
 * ``--prefix``: version prefix for app. It is added to timestamp.
 * ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
-* ``--docker_compose``: File path used as ``docker-compose.yml``.
+* ``--docker-compose``: File path used as ``docker-compose.yml``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.
@@ -141,7 +141,7 @@ This will
 * ``--prefix``: version prefix for app. It is added to timestamp.
 * ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
-* ``--docker_compose``: File path used as ``docker-compose.yml``.
+* ``--docker-compose``: File path used as ``docker-compose.yml``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ To deploy app with cloning, just type it on project root::
 This will
 
 1. Create clone of master environment for next version environment.
-1. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions`` or ``docker-compose.yml`` and ``.ebextensions``
+2. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions`` or ``docker-compose.yml`` and ``.ebextensions``
 3. Uploading zip to S3 as same directory as ``awsebcli``.
 4. Deploy new version to next version (by calling ``eb deploy`` with uploaded --version)
 5. Apply master cname for deployed (next version) environment
@@ -145,4 +145,3 @@ This will
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.
-

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,7 @@ Elastic Beanstalk Intelligence, Simple CLI tool for ElasticBeanstalk with Docker
 
   * Without git integration
   * Switch-able ``Dockerrun.aws.json``
+  * Switch-able ``docker-compose.yml``
   * Switch-able ``.ebextensions/``
 
 Install
@@ -31,15 +32,17 @@ To deploy app, just type it on project root::
 
 This will
 
-1. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions``
+1. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions`` or ``docker-compose.yml`` and ``.ebextensions``
 2. Uploading zip to S3 as same directory as ``awsebcli``.
 3. Deploying app (by calling ``eb deploy`` with uploaded --version)
 
 options:
 
 * ``--version``: version label for app. default is timestamp.
+* ``--prefix``: version prefix for app. It is added to timestamp.
 * ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
+* ``--docker_compose``: File path used as ``docker-compose.yml``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.
@@ -53,15 +56,17 @@ To create app, just type it on project root::
 
 This will
 
-1. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions``
+1. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions`` or ``docker-compose.yml`` and ``.ebextensions``
 2. Uploading zip to S3 as same directory as ``awsebcli``.
 3. Creating app (by calling ``eb create`` with uploaded --version)
 
 options:
 
 * ``--version``: version label for app. default is timestamp.
+* ``--prefix``: version prefix for app. It is added to timestamp.
 * ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
+* ``--docker_compose``: File path used as ``docker-compose.yml``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.
@@ -76,7 +81,7 @@ To Blue-Green deploye app, just type it on project root::
 
 This will
 
-1. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions``
+1. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions`` or ``docker-compose.yml`` and ``.ebextensions``
 2. Uploading zip to S3 as same directory as ``awsebcli``.
 3. Deploy new version to secondary environment which doen't have ``primary_env_cname``
    (by calling ``eb deploy`` with uploaded --version)
@@ -96,8 +101,10 @@ options:
 
 * ``--noswap``: Skip swapping to just deploy secondary environment.
 * ``--version``: version label for app. default is timestamp.
+* ``--prefix``: version prefix for app. It is added to timestamp.
 * ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
+* ``--docker_compose``: File path used as ``docker-compose.yml``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.
@@ -113,7 +120,7 @@ To deploy app with cloning, just type it on project root::
 This will
 
 1. Create clone of master environment for next version environment.
-2. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions``
+1. Create zip file including ``Dockerrun.aws.json`` and ``.ebextensions`` or ``docker-compose.yml`` and ``.ebextensions``
 3. Uploading zip to S3 as same directory as ``awsebcli``.
 4. Deploy new version to next version (by calling ``eb deploy`` with uploaded --version)
 5. Apply master cname for deployed (next version) environment
@@ -131,8 +138,10 @@ This will
 
 * ``--noswap``: Skip swapping to just deploy secondary environment.
 * ``--version``: version label for app. default is timestamp.
+* ``--prefix``: version prefix for app. It is added to timestamp.
 * ``--description``: description for this version.
 * ``--dockerrun``: File path used as ``Dockerrun.aws.json``.
+* ``--docker_compose``: File path used as ``docker-compose.yml``.
 * ``--ebext``: Directory path used as ``.ebextensions/``
 * ``--profile``: Configured profile for AWS.
 * ``--region``: region for AWS.

--- a/ebi/appversion.py
+++ b/ebi/appversion.py
@@ -12,15 +12,17 @@ logger = logging.getLogger('ebi')
 
 
 DOCKERRUN_NAME = 'Dockerrun.aws.json'
+DOCKER_COMPOSE_NAME = 'docker-compose.yml'
 DOCKEREXT_NAME = '.ebextensions/'
 
 
-def make_version_file(version_label, dockerrun=None, ebext=None):
+def make_version_file(version_label, dockerrun=None, docker_compose=None, ebext=None):
     """ Making zip file to upload for ElasticBeanstalk
 
     :param version_label: will be name of the created zip file
 
     * Including :param dockerrun: file as Dockerrun.aws.json
+    * Including :param docker-compose: file as dockerrun-compose.yml (for Amazon linux2)
     * Including :param exext: directory as .ebextensions/
 
     :return: File path to created zip file (current directory).
@@ -30,10 +32,17 @@ def make_version_file(version_label, dockerrun=None, ebext=None):
 
     tempd = tempfile.mkdtemp()
     try:
-        deploy_dockerrun = os.path.join(tempd, DOCKERRUN_NAME)
         deploy_ebext = os.path.join(tempd, DOCKEREXT_NAME)
-        shutil.copyfile(dockerrun, deploy_dockerrun)
         shutil.copytree(ebext, deploy_ebext)
+
+        # docker-compose takes precedence over dockerrun
+        if docker_compose:
+            deploy_docker_compose = os.path.join(tempd, DOCKER_COMPOSE_NAME)
+            shutil.copyfile(docker_compose, deploy_docker_compose)
+        else:
+            deploy_dockerrun = os.path.join(tempd, DOCKERRUN_NAME)
+            shutil.copyfile(dockerrun, deploy_dockerrun)
+            
         return shutil.make_archive(version_label, 'zip', root_dir=tempd)
     finally:
         shutil.rmtree(tempd)
@@ -56,8 +65,8 @@ def upload_app_version(app_name, bundled_zip):
     return bucket, key
 
 
-def make_application_version(app_name, version, dockerrun, ebext, description):
-    bundled_zip = make_version_file(version, dockerrun=dockerrun, ebext=ebext)
+def make_application_version(app_name, version, dockerrun, docker_compose, ebext, description):
+    bundled_zip = make_version_file(version, dockerrun=dockerrun, docker_compose=docker_compose, ebext=ebext)
     try:
         bucket, key = upload_app_version(app_name, bundled_zip)
 

--- a/ebi/commands/bgdeploy.py
+++ b/ebi/commands/bgdeploy.py
@@ -191,7 +191,7 @@ def apply_args(parser):
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
-    parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
+    parser.add_argument('--docker-compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
     parser.add_argument('--capacity', help='Set the number of instances.',
                         action='store_true', default=False)

--- a/ebi/commands/bgdeploy.py
+++ b/ebi/commands/bgdeploy.py
@@ -118,7 +118,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
     logger.info('Ok, now deploying the version %s for %s', version, secondary_env_name)
     payload = ['eb', 'deploy', secondary_env_name,
                '--version=' + version]
@@ -188,6 +188,7 @@ def apply_args(parser):
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
+    parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
     parser.add_argument('--capacity', help='Set the number of instances.',
                         action='store_true', default=False)

--- a/ebi/commands/bgdeploy.py
+++ b/ebi/commands/bgdeploy.py
@@ -110,6 +110,8 @@ def main(parsed):
     ###
     if parsed.version:
         version = parsed.version
+    elif parsed.prefix :
+        version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
 
@@ -184,6 +186,7 @@ def apply_args(parser):
                                          'environment',
                         action='store_true', default=False)
     parser.add_argument('--version', help='Version label you want to specify')
+    parser.add_argument('--prefix', help='Version label prefix you want to specify')
     parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')

--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -82,7 +82,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
     logger.info('Ok, now deploying the version %s for %s', version, next_env_name)
     payload = ['eb', 'deploy', next_env_name,
                '--version=' + version]
@@ -127,6 +127,7 @@ def apply_args(parser):
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
+    parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
     parser.add_argument('--exact', help='Prevents Elastic Beanstalk from updating'
                                         'the solution stack version',

--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -74,6 +74,8 @@ def main(parsed):
     ###
     if parsed.version:
         version = parsed.version
+    elif parsed.prefix :
+        version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
 
@@ -123,6 +125,7 @@ def apply_args(parser):
                                          'environment',
                         action='store_true', default=False)
     parser.add_argument('--version', help='Version label you want to specify')
+    parser.add_argument('--prefix', help='Version label prefix you want to specify')
     parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')

--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -130,7 +130,7 @@ def apply_args(parser):
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
-    parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
+    parser.add_argument('--docker-compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
     parser.add_argument('--exact', help='Prevents Elastic Beanstalk from updating'
                                         'the solution stack version',

--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 def main(parsed):
     if parsed.version:
         version = parsed.version
+    elif parsed.prefix :
+        version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
 
@@ -40,6 +42,7 @@ def apply_args(parser):
     parser.add_argument('env_name', help='Environ name to deploy')
     parser.add_argument('cname', help='cname for created server')
     parser.add_argument('--version', help='Version label you want to specify')
+    parser.add_argument('--prefix', help='Version label prefix you want to specify')
     parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')

--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -47,7 +47,7 @@ def apply_args(parser):
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
-    parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
+    parser.add_argument('--docker-compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
     parser.add_argument('--cfg', help='Configuration template name to eb create')
     parser.set_defaults(func=main)

--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -19,7 +19,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
 
     logger.info('Ok, now creating version %s for environment %s', version, parsed.env_name)
     payload = ['eb', 'create', parsed.env_name,
@@ -44,6 +44,7 @@ def apply_args(parser):
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
+    parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
     parser.add_argument('--cfg', help='Configuration template name to eb create')
     parser.set_defaults(func=main)

--- a/ebi/commands/deploy.py
+++ b/ebi/commands/deploy.py
@@ -19,7 +19,7 @@ def main(parsed):
     else:
         description = ''
 
-    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.ebext, description)
+    appversion.make_application_version(parsed.app_name, version, parsed.dockerrun, parsed.docker_compose, parsed.ebext, description)
     logger.info('Ok, now deploying the version %s for %s', version, parsed.env_name)
     payload = ['eb', 'deploy', parsed.env_name,
                '--version=' + version]
@@ -40,6 +40,7 @@ def apply_args(parser):
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
+    parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
     parser.add_argument('--staged', action='store_true', default=False,
                         help='deploy files staged in git rather than the HEAD commit')

--- a/ebi/commands/deploy.py
+++ b/ebi/commands/deploy.py
@@ -43,7 +43,7 @@ def apply_args(parser):
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
-    parser.add_argument('--docker_compose', help='Path to file used as docker-compose.yml')
+    parser.add_argument('--docker-compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')
     parser.add_argument('--staged', action='store_true', default=False,
                         help='deploy files staged in git rather than the HEAD commit')

--- a/ebi/commands/deploy.py
+++ b/ebi/commands/deploy.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 def main(parsed):
     if parsed.version:
         version = parsed.version
+    elif parsed.prefix :
+        version = "{}_{}".format(parsed.prefix, int(time.time()))
     else:
         version = str(int(time.time()))
 
@@ -36,6 +38,7 @@ def apply_args(parser):
     parser.add_argument('app_name', help='Application name to deploy')
     parser.add_argument('env_name', help='Environ name to deploy')
     parser.add_argument('--version', help='Version label you want to specify')
+    parser.add_argument('--prefix', help='Version label prefix you want to specify')
     parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open('./README.rst').read()
 
 setup(
     name='ebi',
-    version='0.8.0',
+    version='0.9.0',
     install_requires=[
         'awsebcli>=3.7.3,<4',
         'boto3>=1.2.6,<2',


### PR DESCRIPTION
## Abstract
- Add two params to each command
  - `--docker-compose` 
    - Use docker-compose.yml instead of `Dockerrun.aws.json` to deploy an application on Amazon Linux 2
    - ref https://docs.aws.amazon.com/ja_jp/elasticbeanstalk/latest/dg/using-features.migration-al.html
  - `--prefix`
    - Add version prefix to the beginning of timestamp
    - e.g. `--prefix dev` -> dev_1608617045