### PR TITLE
Add timeout option

### DIFF
--- a/ebi/commands/bgdeploy.py
+++ b/ebi/commands/bgdeploy.py
@@ -128,6 +128,8 @@ def main(parsed):
         payload.append('--profile=' + parsed.profile)
     if parsed.region:
         payload.append('--region=' + parsed.region)
+    if parsed.timeout:
+        payload.append('--timeout=' + parsed.timeout)
     r = subprocess.call(payload)
     if r != 0:
         logger.error("Failed to deploy version %s to environment %s",
@@ -190,6 +192,7 @@ def apply_args(parser):
     parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
+    parser.add_argument('--timeout', help='The number of minutes before the deploy timeout')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker-compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')

--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -60,6 +60,8 @@ def main(parsed):
         payload.append('--profile=' + parsed.profile)
     if parsed.region:
         payload.append('--region=' + parsed.region)
+    if parsed.timeout:
+        payload.append('--timeout=' + parsed.timeout)
     if parsed.exact:
         payload.append('--exact')
 
@@ -92,6 +94,8 @@ def main(parsed):
         payload.append('--profile=' + parsed.profile)
     if parsed.region:
         payload.append('--region=' + parsed.region)
+    if parsed.timeout:
+        payload.append('--timeout=' + parsed.timeout)
     r = subprocess.call(payload)
     if r != 0:
         logger.error("Failed to deploy version %s to environment %s",
@@ -129,6 +133,7 @@ def apply_args(parser):
     parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
+    parser.add_argument('--timeout', help='The number of minutes before the deploy timeout')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker-compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')

--- a/ebi/commands/create.py
+++ b/ebi/commands/create.py
@@ -34,6 +34,8 @@ def main(parsed):
         payload.append('--cfg=' + parsed.cfg)
     if parsed.region:
         payload.append('--region=' + parsed.region)
+    if parsed.timeout:
+        payload.append('--timeout=' + parsed.timeout)
     sys.exit(subprocess.call(payload))
 
 
@@ -46,6 +48,7 @@ def apply_args(parser):
     parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
+    parser.add_argument('--timeout', help='The number of minutes before the deploy timeout')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker-compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')

--- a/ebi/commands/deploy.py
+++ b/ebi/commands/deploy.py
@@ -29,6 +29,8 @@ def main(parsed):
         payload.append('--profile=' + parsed.profile)
     if parsed.region:
         payload.append('--region=' + parsed.region)
+    if parsed.timeout:
+        payload.append('--timeout=' + parsed.timeout)
     if parsed.staged:
         payload.append('--staged')
     sys.exit(subprocess.call(payload))
@@ -42,6 +44,7 @@ def apply_args(parser):
     parser.add_argument('--description', help='Description for this version')
     parser.add_argument('--profile', help='AWS account')
     parser.add_argument('--region', help='AWS region')
+    parser.add_argument('--timeout', help='The number of minutes before the deploy timeout')
     parser.add_argument('--dockerrun', help='Path to file used as Dockerrun.aws.json')
     parser.add_argument('--docker-compose', help='Path to file used as docker-compose.yml')
     parser.add_argument('--ebext', help='Path to directory used as .ebextensions/')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open('./README.rst').read()
 
 setup(
     name='ebi',
-    version='0.9.0',
+    version='0.10.0',
     install_requires=[
         'awsebcli>=3.7.3,<4',
         'boto3>=1.2.6,<2',


### PR DESCRIPTION
Add `--timeout` param to each command.

This param will be passed directly to the eb command.
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb3-deploy.html

Some deployment methods take more than the default 10 minutes to process.
