### PR TITLE
Support dockerrunfile with docker-compose

### DIFF
--- a/ebi/appversion.py
+++ b/ebi/appversion.py
@@ -29,8 +29,6 @@ def make_version_file_with_ebignore(version_label, dockerrun=None, docker_compos
 
     :return: File path to created zip file (current directory).
     """
-    dockerrun = dockerrun or DOCKERRUN_NAME
-
     ebext = ebext or DOCKEREXT_NAME
 
     tempd = tempfile.mkdtemp()
@@ -61,7 +59,10 @@ def make_version_file_with_ebignore(version_label, dockerrun=None, docker_compos
 
             if docker_compose:
                 f.write(docker_compose, arcname=DOCKER_COMPOSE_NAME)
+                if dockerrun:
+                    f.write(dockerrun, arcname=DOCKERRUN_NAME)
             else:
+                dockerrun = dockerrun or DOCKERRUN_NAME
                 f.write(dockerrun, arcname=DOCKERRUN_NAME)
 
         return zip_filename


### PR DESCRIPTION
Even if using docker-compose in AL2, there are cases where dockerrun file is used together. 
(Dockerrun.aws.json v3)
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/single-container-docker-configuration.html#docker-configuration.remote-repo

When you explicitly specify both docker-compose and dockerrun settings in ebi command, the process should refer to both.