### PR TITLE
Fix ProfileNotFound when credentials come only from environment variables

### DIFF
--- a/ebi/core.py
+++ b/ebi/core.py
@@ -47,5 +47,9 @@ def main():
     boto3.setup_default_session(**conf)
     session = boto3._get_default_session()
     ebaws.set_region(session._session.get_config_variable('region'))
-    ebaws.set_profile(session.profile_name)
+    # Session.profile_name falls back to 'default', which would make
+    # botocore ignore credentials from environment variables.
+    profile = session._session.get_config_variable('profile')
+    if profile:
+        ebaws.set_profile(profile)
     parsed.func(parsed)


### PR DESCRIPTION
## Problem

Running any ebi command without `--profile` fails with `ProfileNotFound: The config profile (default) could not be found` when credentials are provided only via environment variables (no `~/.aws/credentials`) — a common setup on CI services (e.g. GitHub Actions with OIDC-issued credentials).

`main()` calls `ebaws.set_profile(session.profile_name)` unconditionally. boto3's `Session.profile_name` returns `'default'` even when no profile is configured, so ebcli/botocore receives it as an explicitly requested profile. botocore then removes the env credential provider from the chain and requires the profile to exist in a config file.

## Fix

Propagate a profile to ebcli only when one was explicitly configured (`--profile` or `AWS_PROFILE`).

Verified with awsebcli 3.x / Python 3.12, resolving credentials through `ebcli.lib.aws` (no network needed):

| case | before | after |
|---|---|---|
| no profile, env credentials only | `ProfileNotFound` | env credentials resolved |
| `--profile myprof` (exists in file) | profile used | unchanged |
| `AWS_PROFILE=envpro` (exists in file) | profile used | unchanged |

## Note

If both a `default` profile in `~/.aws/credentials` and env credentials are present, env credentials now take precedence (matching the standard AWS credential chain used by the AWS CLI / boto3).