### PR TITLE
Fix small issues: zip compression, dead code, error messages, typos

### DIFF
--- a/ebi/appversion.py
+++ b/ebi/appversion.py
@@ -19,13 +19,13 @@ DOCKEREXT_NAME = '.ebextensions/'
 
 
 def make_version_file_with_ebignore(version_label, dockerrun=None, docker_compose=None, ebext=None):
-    """ Making zip file to upload for ElasticBeanstalk based on ebigore
+    """ Making zip file to upload for ElasticBeanstalk based on ebignore
 
     :param version_label: will be name of the created zip file
 
     * Including :param dockerrun: file as Dockerrun.aws.json
-    * Including :param docker-compose: file as docker-compose.yml (for Amazon linux2)
-    * Including :param exext: directory as .ebextensions/
+    * Including :param docker_compose: file as docker-compose.yml (for Amazon linux2)
+    * Including :param ebext: directory as .ebextensions/
 
     :return: File path to created zip file (current directory).
     """
@@ -35,7 +35,7 @@ def make_version_file_with_ebignore(version_label, dockerrun=None, docker_compos
     try:
         ignore_files = fileoperations.get_ebignore_list()
 
-        # Dockerrun, docker-compose and ebextentions files are added to zip file later.
+        # Dockerrun, docker-compose and ebextensions files are added to zip file later.
         ignore_files |= {DOCKERRUN_NAME, DOCKER_COMPOSE_NAME}
         ignore_ebext_files = set()
         for file in os.listdir(DOCKEREXT_NAME):
@@ -50,7 +50,7 @@ def make_version_file_with_ebignore(version_label, dockerrun=None, docker_compos
         shutil.copyfile(temp_zip_path, zip_filename)
 
         logger.info(f'Adding {DOCKERRUN_NAME}, {DOCKER_COMPOSE_NAME}, {DOCKEREXT_NAME} to archive.')
-        with zipfile.ZipFile(zip_filename, 'a', allowZip64=True) as f:
+        with zipfile.ZipFile(zip_filename, 'a', compression=zipfile.ZIP_DEFLATED, allowZip64=True) as f:
             for file in os.listdir(ebext):
                 source_ebext_file_path = os.path.join(ebext, file)
                 target_ebext_file_path = os.path.join(DOCKEREXT_NAME, file)
@@ -77,7 +77,7 @@ def make_version_file(version_label, dockerrun=None, docker_compose=None, ebext=
     :param version_label: will be name of the created zip file
 
     * Including :param dockerrun: file as Dockerrun.aws.json
-    * Including :param docker-compose: file as docker-compose.yml (for Amazon linux2)
+    * Including :param docker_compose: file as docker-compose.yml (for Amazon linux2)
     * Including :param ebext: directory as .ebextensions/
 
     :return: File path to created zip file (current directory).
@@ -114,7 +114,8 @@ def upload_app_version(app_name, bundled_zip):
     key = app_name + '/' + os.path.basename(bundled_zip)
     try:
         ebs3.get_object_info(bucket, key)
-        logger.info('S3 Object already exists. Skipping upload.')
+        logger.warning('S3 object already exists at %s. Skipping upload and reusing the existing object; '
+                       'it may not match your local bundle.', key)
     except NotFoundError:
         logger.info('Uploading archive to s3 location: ' + key)
         ebs3.upload_application_version(bucket, key, bundled_zip)

--- a/ebi/commands/bgdeploy.py
+++ b/ebi/commands/bgdeploy.py
@@ -14,18 +14,17 @@ def get_environ_name_for_cname(app_name, cname):
     """ Determine environment name having :param cname: on :param app_name:.
 
     If cname duplicated, longer one will be returned.
-    For example, there are myenv.ap-northeast-1.elasticbeanstalk.com and myenv.elasticbeanstal.com,
-    myenv.ap-northeast-1.elasticbeanstal.com will be returned.
+    For example, there are myenv.ap-northeast-1.elasticbeanstalk.com and myenv.elasticbeanstalk.com,
+    myenv.ap-northeast-1.elasticbeanstalk.com will be returned.
     """
     eb = boto3.client('elasticbeanstalk')
     res = eb.describe_environments(ApplicationName=app_name)
-    if res['ResponseMetadata']['HTTPStatusCode'] != 200:
-        raise ValueError('ElasticBeanstalk client did not return 200 for describing environments')
 
     for e in reversed(sorted(res['Environments'], key=lambda x: len(x['CNAME']))):
         if e['CNAME'].startswith(cname + '.'):
             return e['EnvironmentName']
-    raise ValueError('Could not find environment for applied app_name and cname')
+    logger.error('Could not find environment for applied app_name and cname')
+    sys.exit(1)
 
 
 def get_instance_health(group_name, number):
@@ -37,13 +36,20 @@ def get_instance_health(group_name, number):
     if instance_number != number:
         return False
 
-    for instance in instances:
-        # Wait for the all of instance status to be healthy.
-        ec2 = boto3.client('ec2')
-        instance = ec2.describe_instance_status(InstanceIds=[instance['InstanceId']])
-        if not instance['InstanceStatuses']:
-            return False
-        elif instance['InstanceStatuses'][0]['InstanceStatus']['Status'] != 'ok':
+    if not instances:
+        return True
+
+    # Wait for the all of instance status to be healthy.
+    ec2 = boto3.client('ec2')
+    res = ec2.describe_instance_status(
+        InstanceIds=[instance['InstanceId'] for instance in instances])
+    statuses = res['InstanceStatuses']
+    # describe_instance_status returns only running instances by default,
+    # so fewer statuses than instances means some are not running yet.
+    if len(statuses) != instance_number:
+        return False
+    for status in statuses:
+        if status['InstanceStatus']['Status'] != 'ok':
             return False
     return True
 
@@ -103,7 +109,8 @@ def main(parsed):
         primary_env_name = parsed.green_env
         secondary_env_name = parsed.blue_env
     else:
-        raise ValueError('master env for cname {p.cname} was not in {p.app_name}'.format(p=parsed))
+        logger.error('master env for cname %s was not in %s', parsed.cname, parsed.app_name)
+        sys.exit(1)
 
     ###
     # Deploying

--- a/ebi/commands/clonedeploy.py
+++ b/ebi/commands/clonedeploy.py
@@ -14,19 +14,17 @@ def get_environ_name_for_cname(app_name, cname):
     """ Determine environment name having :param cname: on :param app_name:.
 
     If cname duplicated, longer one will be returned.
-    For example, there are myenv.ap-northeast-1.elasticbeanstalk.com and myenv.elasticbeanstal.com,
-    myenv.ap-northeast-1.elasticbeanstal.com will be returned.
+    For example, there are myenv.ap-northeast-1.elasticbeanstalk.com and myenv.elasticbeanstalk.com,
+    myenv.ap-northeast-1.elasticbeanstalk.com will be returned.
     """
     eb = boto3.client('elasticbeanstalk')
     res = eb.describe_environments(ApplicationName=app_name)
 
-    if res['ResponseMetadata']['HTTPStatusCode'] != 200:
-        raise ValueError('ElasticBeanstalk client did not return 200 for describing environments')
-
     for e in reversed(sorted(res['Environments'], key=lambda x: len(x['CNAME']))):
         if e['CNAME'].startswith(cname + '.'):
             return e['EnvironmentName']
-    raise ValueError('Could not find environment for applied app_name and cname')
+    logger.error('Could not find environment for applied app_name and cname')
+    sys.exit(1)
 
 
 def base36encode(num):

--- a/ebi/core.py
+++ b/ebi/core.py
@@ -17,7 +17,6 @@ def main():
     """ Main function called from console_scripts
     """
     logger = logging.getLogger('ebi')
-    logger.propagate = True
     logger.setLevel(logging.INFO)
     logger.addHandler(logging.StreamHandler())
 


### PR DESCRIPTION
Small fixes raised in code review. Intentionally scoped to minor items only; the `--use-ebignore` bug, code deduplication, and Python 2 leftovers are being handled in separate PRs.

## Changes

- **Zip compression** (`ebi/appversion.py`): pass `compression=zipfile.ZIP_DEFLATED` when appending Dockerrun / docker-compose / `.ebextensions` files to the version bundle. Without it, appended files were stored uncompressed (`ZIP_STORED`).
- **S3 reuse warning** (`ebi/appversion.py`): when the S3 key already exists, log at `warning` level (was `info`) and include the key name plus a note that the existing object is reused. This makes the stale-bundle risk visible when re-running with a fixed `--version`.
- **`get_instance_health` efficiency** (`ebi/commands/bgdeploy.py`): create the EC2 client once outside the loop and check all instances with a single `describe_instance_status(InstanceIds=[...])` call instead of one call per instance. Judgment logic is unchanged: missing statuses (e.g. instances not yet running, which the API omits by default) or any status other than `ok` still return `False`.
- **Dead code removal** (`ebi/commands/bgdeploy.py`, `ebi/commands/clonedeploy.py`): drop the unreachable `if res['ResponseMetadata']['HTTPStatusCode'] != 200: raise ValueError(...)` checks; boto3 raises `ClientError` for non-2xx responses.
- **Friendlier CLI errors** (`ebi/commands/bgdeploy.py`, `ebi/commands/clonedeploy.py`): user-facing failures ("environment not found for cname", "master env is neither blue nor green") now print a `logger.error` message and `sys.exit(1)` instead of dumping a raw traceback.
- **Typo fixes**: `ebigore` → `ebignore`, `:param exext:` → `:param ebext:`, `ebextentions` → `ebextensions`, `:param docker-compose:` → `:param docker_compose:` in `ebi/appversion.py`; `elasticbeanstal.com` → `elasticbeanstalk.com` in the docstrings of `bgdeploy.py` and `clonedeploy.py` (2 occurrences each).
- **Redundant logger setting** (`ebi/core.py`): remove `logger.propagate = True` (it is the default).

## Verification

- `python3 -m compileall ebi` passes
- `ebi --help` runs and prints usage