### PR TITLE
Add regression tests for profile/session setup (stacked on #27)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -e . pytest
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,20 @@ name: test
 
 on:
   push:
+    branches: [master]
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ env/
 .idea/
 dist/
 build/
+.pytest_cache/

--- a/ebi/core.py
+++ b/ebi/core.py
@@ -13,6 +13,29 @@ from .commands.create import apply_args as apply_args_create
 from .commands.deploy import apply_args as apply_args_deploy
 
 
+def setup_session(profile=None, region=None):
+    """ Configure the default boto3 session and propagate it to ebcli.
+
+    Note this depends on private boto3/botocore APIs
+    (``boto3._get_default_session()`` and
+    ``session._session.get_config_variable(...)``); the assumptions are
+    pinned down by the tests in tests/test_private_api_assumptions.py.
+    """
+    conf = {}
+    if profile:
+        conf['profile_name'] = profile
+    if region:
+        conf['region_name'] = region
+    boto3.setup_default_session(**conf)
+    session = boto3._get_default_session()
+    ebaws.set_region(session._session.get_config_variable('region'))
+    # Session.profile_name falls back to 'default', which would make
+    # botocore ignore credentials from environment variables.
+    profile = session._session.get_config_variable('profile')
+    if profile:
+        ebaws.set_profile(profile)
+
+
 def main():
     """ Main function called from console_scripts
     """
@@ -39,17 +62,5 @@ def main():
         parser.print_help()
         return
 
-    conf = {}
-    if parsed.profile:
-        conf['profile_name'] = parsed.profile
-    if parsed.region:
-        conf['region_name'] = parsed.region
-    boto3.setup_default_session(**conf)
-    session = boto3._get_default_session()
-    ebaws.set_region(session._session.get_config_variable('region'))
-    # Session.profile_name falls back to 'default', which would make
-    # botocore ignore credentials from environment variables.
-    profile = session._session.get_config_variable('profile')
-    if profile:
-        ebaws.set_profile(profile)
+    setup_session(parsed.profile, parsed.region)
     parsed.func(parsed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+"""Shared fixtures isolating tests from real AWS config and global state.
+
+ebi/core.py wires the default boto3 session into ebcli's module-level
+state (ebcli.lib.aws), so every test must start from a clean slate:
+
+* environment variables that influence credential/profile resolution,
+* boto3.DEFAULT_SESSION (set by boto3.setup_default_session),
+* ebcli.lib.aws module globals (_profile, _region_name, the cached
+  botocore session, client cache, ...) -- reset via its own _flush()
+  helper, plus _profile_env_var/_endpoint_url which _flush() skips.
+
+No test here performs network access: resolving credentials from
+environment variables or from a credentials file is purely local.
+"""
+
+import boto3
+import pytest
+
+from ebcli.lib import aws as ebaws
+
+# Environment variables that affect profile/credential/region resolution.
+AWS_ENV_VARS = (
+    'AWS_PROFILE',
+    'AWS_DEFAULT_PROFILE',
+    'AWS_EB_PROFILE',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_SECURITY_TOKEN',
+    'AWS_DEFAULT_REGION',
+    'AWS_REGION',
+    'AWS_CONFIG_FILE',
+    'AWS_SHARED_CREDENTIALS_FILE',
+)
+
+
+def _reset_global_state():
+    # boto3 caches the default session at module level.
+    boto3.DEFAULT_SESSION = None
+    # ebcli.lib.aws provides _flush() "for resetting tests only"; it
+    # resets _api_clients, _profile, _id, _key, _region_name,
+    # _verify_ssl and the cached botocore session.
+    ebaws._flush()
+    # Not covered by _flush(); restore the import-time defaults.
+    ebaws._profile_env_var = 'AWS_EB_PROFILE'
+    ebaws._endpoint_url = None
+
+
+@pytest.fixture(autouse=True)
+def isolated_aws_env(monkeypatch, tmp_path):
+    """Isolate each test from real ~/.aws files, env vars and globals.
+
+    HOME points at an empty temporary directory, so no real config or
+    credentials files leak in; tests opt in to credentials via env vars
+    or by writing files under this HOME.
+    """
+    home = tmp_path / 'home'
+    home.mkdir()
+    monkeypatch.setenv('HOME', str(home))
+    for var in AWS_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    _reset_global_state()
+    yield home
+    _reset_global_state()
+
+
+@pytest.fixture
+def write_credentials_file(isolated_aws_env):
+    """Return a helper writing a profile into ~/.aws/credentials."""
+
+    def _write(profile, access_key, secret_key):
+        aws_dir = isolated_aws_env / '.aws'
+        aws_dir.mkdir(exist_ok=True)
+        credentials = aws_dir / 'credentials'
+        with credentials.open('a') as f:
+            f.write(
+                '[{0}]\n'
+                'aws_access_key_id = {1}\n'
+                'aws_secret_access_key = {2}\n'.format(
+                    profile, access_key, secret_key)
+            )
+
+    return _write

--- a/tests/test_private_api_assumptions.py
+++ b/tests/test_private_api_assumptions.py
@@ -1,0 +1,75 @@
+"""Pin the private boto3/botocore APIs that ebi.core depends on.
+
+ebi.core.setup_session relies on:
+
+* boto3._get_default_session()                       (private function)
+* boto3.Session._session                             (private attribute,
+  the underlying botocore session)
+* botocore_session.get_config_variable('profile')    (returns None when
+  no profile is configured, the env var value when AWS_PROFILE is set)
+
+If a boto3/botocore upgrade ever breaks these assumptions, these tests
+fail and point straight at the contract instead of producing an obscure
+runtime error in ebi.
+"""
+
+import boto3
+import botocore.session
+
+
+class TestGetDefaultSession:
+    def test_boto3_exposes_get_default_session(self):
+        assert hasattr(boto3, '_get_default_session')
+        assert callable(boto3._get_default_session)
+
+    def test_returns_the_session_created_by_setup_default_session(self):
+        boto3.setup_default_session()
+        session = boto3._get_default_session()
+        assert isinstance(session, boto3.Session)
+        assert session is boto3.DEFAULT_SESSION
+
+    def test_session_wraps_a_botocore_session(self):
+        boto3.setup_default_session()
+        session = boto3._get_default_session()
+        assert isinstance(session._session, botocore.session.Session)
+
+
+class TestProfileConfigVariable:
+    def test_profile_is_none_when_not_configured(self):
+        """The very assumption behind the PR #27 fix.
+
+        With no --profile, no AWS_PROFILE and no config files, the
+        botocore config variable 'profile' must be None so that ebi
+        skips ebaws.set_profile entirely.
+        """
+        boto3.setup_default_session()
+        session = boto3._get_default_session()
+        assert session._session.get_config_variable('profile') is None
+
+    def test_profile_name_falls_back_to_default(self):
+        """Documents why Session.profile_name cannot be used instead.
+
+        profile_name is 'default' even when nothing is configured;
+        propagating it to ebcli is exactly the regression fixed by
+        PR #27 (ProfileNotFound for env-only credentials).
+        """
+        boto3.setup_default_session()
+        session = boto3._get_default_session()
+        assert session.profile_name == 'default'
+
+    def test_profile_reflects_aws_profile_env_var(
+            self, monkeypatch, write_credentials_file):
+        # The profile must exist: boto3.Session.__init__ resolves scoped
+        # config during _setup_loader and raises ProfileNotFound otherwise.
+        write_credentials_file('envprofile', 'AKIAENVPROFILE', 'env-secret')
+        monkeypatch.setenv('AWS_PROFILE', 'envprofile')
+        boto3.setup_default_session()
+        session = boto3._get_default_session()
+        assert session._session.get_config_variable('profile') == 'envprofile'
+
+    def test_profile_reflects_explicit_profile_name(
+            self, write_credentials_file):
+        write_credentials_file('cliprofile', 'AKIACLIPROFILE', 'cli-secret')
+        boto3.setup_default_session(profile_name='cliprofile')
+        session = boto3._get_default_session()
+        assert session._session.get_config_variable('profile') == 'cliprofile'

--- a/tests/test_setup_session.py
+++ b/tests/test_setup_session.py
@@ -1,0 +1,110 @@
+"""Regression tests for ebi.core.setup_session (used by main()).
+
+These pin the fix from PR #27: when no profile is configured anywhere,
+ebi must NOT call ebcli.lib.aws.set_profile, because ebcli would then
+pin botocore to the 'default' profile and credentials coming only from
+environment variables (e.g. CI with OIDC-issued credentials) would fail
+with ProfileNotFound.
+"""
+
+import boto3
+
+from ebcli.lib import aws as ebaws
+
+from ebi import core
+
+
+class TestEnvOnlyCredentials:
+    """Credentials only via env vars, no ~/.aws files, no profile."""
+
+    def _setup_env(self, monkeypatch):
+        monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'AKIATESTEXAMPLE')
+        monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'test-secret')
+        monkeypatch.setenv('AWS_DEFAULT_REGION', 'ap-northeast-1')
+
+    def test_no_profile_is_propagated_to_ebcli(self, monkeypatch):
+        self._setup_env(monkeypatch)
+
+        core.setup_session()
+
+        # The regression: main() used to call set_profile('default')
+        # unconditionally via session.profile_name.
+        assert ebaws._profile is None
+
+    def test_credentials_resolve_through_ebcli_session(self, monkeypatch):
+        """ebcli's botocore session must resolve env credentials.
+
+        This is the same in-process path used by
+        appversion.make_application_version via ebcli.lib.s3 /
+        elasticbeanstalk. Before the fix this raised ProfileNotFound.
+        No network access happens during credential resolution.
+        """
+        self._setup_env(monkeypatch)
+
+        core.setup_session()
+
+        creds = ebaws._get_botocore_session().get_credentials()
+        assert creds is not None
+        assert creds.access_key == 'AKIATESTEXAMPLE'
+        assert creds.secret_key == 'test-secret'
+
+    def test_region_is_propagated_to_ebcli(self, monkeypatch):
+        self._setup_env(monkeypatch)
+
+        core.setup_session()
+
+        assert ebaws.get_region_name() == 'ap-northeast-1'
+
+
+class TestProfileFromEnvVar:
+    """AWS_PROFILE must still be honored and propagated to ebcli."""
+
+    def test_aws_profile_env_var_propagates(
+            self, monkeypatch, write_credentials_file):
+        write_credentials_file('envprofile', 'AKIAENVPROFILE', 'env-secret')
+        monkeypatch.setenv('AWS_PROFILE', 'envprofile')
+
+        core.setup_session()
+
+        assert ebaws._profile == 'envprofile'
+
+    def test_aws_profile_credentials_resolve_through_ebcli_session(
+            self, monkeypatch, write_credentials_file):
+        write_credentials_file('envprofile', 'AKIAENVPROFILE', 'env-secret')
+        monkeypatch.setenv('AWS_PROFILE', 'envprofile')
+
+        core.setup_session()
+
+        creds = ebaws._get_botocore_session().get_credentials()
+        assert creds is not None
+        assert creds.access_key == 'AKIAENVPROFILE'
+
+
+class TestExplicitProfileOption:
+    """--profile on the command line (passed as setup_session(profile=...))."""
+
+    def test_explicit_profile_propagates(self, write_credentials_file):
+        write_credentials_file('cliprofile', 'AKIACLIPROFILE', 'cli-secret')
+
+        core.setup_session(profile='cliprofile')
+
+        assert ebaws._profile == 'cliprofile'
+        assert boto3._get_default_session().profile_name == 'cliprofile'
+
+    def test_explicit_profile_credentials_resolve_through_ebcli_session(
+            self, write_credentials_file):
+        write_credentials_file('cliprofile', 'AKIACLIPROFILE', 'cli-secret')
+
+        core.setup_session(profile='cliprofile')
+
+        creds = ebaws._get_botocore_session().get_credentials()
+        assert creds is not None
+        assert creds.access_key == 'AKIACLIPROFILE'
+
+    def test_explicit_region_propagates(self, monkeypatch):
+        monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'AKIATESTEXAMPLE')
+        monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'test-secret')
+
+        core.setup_session(region='eu-west-1')
+
+        assert ebaws.get_region_name() == 'eu-west-1'


### PR DESCRIPTION
## Summary

Stacked PR on top of #27 (`fix-implicit-default-profile`). Once #27 is merged, the base of this PR should be changed to `master`.

#27 fixed a `ProfileNotFound` error in environments that authenticate only via environment variables (e.g. CI with OIDC-issued credentials), by no longer calling `ebaws.set_profile` when no profile is configured anywhere. That fix had no test coverage, and `ebi/core.py` relies on private boto3/botocore APIs (`boto3._get_default_session()`, `session._session.get_config_variable(...)`) whose behavior could silently change on upgrades. This PR adds regression tests pinning both.

## Changes

- **`ebi/core.py`**: extracted the session setup logic from `main()` into `setup_session(profile=None, region=None)` so it can be tested without argument parsing. `main()` behavior is unchanged (it now just calls `setup_session(parsed.profile, parsed.region)`).
- **`tests/test_setup_session.py`**: pins the behavior fixed by #27:
  - With credentials only from `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (HOME isolated to an empty temp dir, `AWS_PROFILE` etc. removed), no profile is propagated to ebcli and credentials resolve through ebcli's botocore session (`ebcli.lib.aws._get_botocore_session().get_credentials()`) without `ProfileNotFound` — the same in-process path used by `make_application_version`. Verified this test fails against the pre-#27 behavior.
  - `AWS_PROFILE` still propagates to `ebaws.set_profile`.
  - An explicit `--profile` (passed as `setup_session(profile=...)`) still propagates as well.
- **`tests/test_private_api_assumptions.py`**: pins the private-API contract `core.py` depends on, so a boto3/botocore upgrade that breaks the assumptions fails loudly with a pointer to the contract instead of an obscure runtime error:
  - `boto3._get_default_session()` exists and returns the session created by `setup_default_session()`, wrapping a botocore session at `._session`.
  - `get_config_variable('profile')` returns `None` when no profile is configured, and the value when `AWS_PROFILE`/`profile_name` is set.
  - `Session.profile_name` falls back to `'default'` — documenting why it cannot be used (that was exactly the bug #27 fixed).
- **`tests/conftest.py`**: autouse fixture isolating each test — HOME pointed at an empty temp dir, all credential/profile-related `AWS_*` env vars removed (restored via monkeypatch), `boto3.DEFAULT_SESSION` reset, and `ebcli.lib.aws` module globals reset via its own `_flush()` helper plus `_profile_env_var`/`_endpoint_url` which `_flush()` does not cover. No test performs any network access (credential resolution from env vars / a credentials file is purely local).
- **`.github/workflows/test.yml`**: minimal CI running `pytest tests/ -v` on Python 3.12 for `push` and `pull_request`.

## Test results

All 15 tests pass locally (Python 3.12, boto3 1.43.28, awsebcli):

```
tests/test_private_api_assumptions.py ....... (7 passed)
tests/test_setup_session.py ........ (8 passed)
15 passed
```

## Notes for reviewers

- This replaces the manual `repro_profile.py` reproduction script (not committed); its before/after scenarios are now covered by the test suite.
- `boto3.Session.__init__` resolves scoped config during `_setup_loader()`, so tests that set a profile must create it in `~/.aws/credentials` (inside the isolated temp HOME) or boto3 itself raises `ProfileNotFound` before `setup_session` logic is even reached. The tests document this.